### PR TITLE
Bump homebridge to 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/).
+## 2.0.0
+
+* Homebridge v2
 
 ## 1.4.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,8 @@
         "minimist": ">=0.2.1"
       },
       "engines": {
-        "homebridge": ">=0.2.0",
-        "node": ">=0.12.0"
+        "homebridge": "^1.6.0 || ^2.0.0-beta.0",
+        "node": "^18.20.4 || ^20.15.1 || ^22"
       }
     },
     "node_modules/@babel/cli": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-izone-airconditioner",
-  "version": "1.4.2",
+  "version": "2.0.0",
   "description": "Homebridge plugin for the iZone airconditioner controller.",
   "main": "dist/index.js",
   "scripts": {
@@ -16,8 +16,8 @@
     "url": "https://github.com/gondalez/homebridge-izone-airconditioner.git"
   },
   "engines": {
-    "node": ">=0.12.0",
-    "homebridge": ">=0.2.0"
+    "homebridge": "^1.6.0 || ^2.0.0-beta.0",
+    "node": "^18.20.4 || ^20.15.1 || ^22"
   },
   "keywords": [
     "homebridge-plugin",


### PR DESCRIPTION
Homebridge 2.0 is coming and a friendly user reported the plugin already works (https://github.com/gondalez/homebridge-izone-airconditioner/issues/27).

Follow upgrade instructions to get a ✅😌
None of the breaking changes seem to apply, thankfully.
https://github.com/homebridge/homebridge/wiki/Updating-To-Homebridge-v2.0